### PR TITLE
fix: adjust deprecated lookup function

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -12,8 +12,8 @@ locals {
         lookup(v, "name_prefix", "/aws/"),
         module.log_group_prefix.id,
         module.log_group_prefix.delimiter,
-        lookup(v, "name_suffix")
-      ) : lookup(v, "name")
+        v["name_suffix"]
+      ) : v["name"]
       filter_pattern : lookup(v, "filter_pattern", "")
     }
   }

--- a/src/provider-datadog.tf
+++ b/src/provider-datadog.tf
@@ -1,5 +1,5 @@
 module "datadog_configuration" {
-  source                  = "github.com/cloudposse-terraform-components/aws-datadog-credentials?tags=v1.535.1"
+  source                  = "github.com/cloudposse-terraform-components/aws-datadog-credentials?ref=tags/v1.535.1"
   enabled                 = true
   context                 = module.this.context
   global_environment_name = var.datadog_configuration_environment

--- a/src/provider-datadog.tf
+++ b/src/provider-datadog.tf
@@ -1,6 +1,10 @@
 module "datadog_configuration" {
+<<<<<<< Updated upstream
   source = "../datadog-configuration/modules/datadog_keys"
 
+=======
+  source                  = "github.com/cloudposse-terraform-components/aws-datadog-credentials?ref=v1.535.1"
+>>>>>>> Stashed changes
   enabled                 = true
   context                 = module.this.context
   global_environment_name = var.datadog_configuration_environment

--- a/src/provider-datadog.tf
+++ b/src/provider-datadog.tf
@@ -1,5 +1,7 @@
 module "datadog_configuration" {
-  source                  = "../datadog-configuration/modules/datadog_keys"
+  source  = "github.com/cloudposse-terraform-components/aws-datadog-credentials/modules/datadog_keys"
+  version = "v1.535.0"
+
   enabled                 = true
   context                 = module.this.context
   global_environment_name = var.datadog_configuration_environment

--- a/src/provider-datadog.tf
+++ b/src/provider-datadog.tf
@@ -1,5 +1,5 @@
 module "datadog_configuration" {
-  source = "git::https://github.com/cloudposse-terraform-components/aws-datadog-credentials.git//modules/datadog_keys?ref=v1.535.0"
+  source = "git::https://github.com/cloudposse-terraform-components/aws-datadog-credentials.git//src/modules/datadog_keys?ref=v1.535.0"
 
   enabled                 = true
   context                 = module.this.context

--- a/src/provider-datadog.tf
+++ b/src/provider-datadog.tf
@@ -1,10 +1,5 @@
 module "datadog_configuration" {
-<<<<<<< Updated upstream
-  source = "../datadog-configuration/modules/datadog_keys"
-
-=======
   source                  = "github.com/cloudposse-terraform-components/aws-datadog-credentials?ref=v1.535.1"
->>>>>>> Stashed changes
   enabled                 = true
   context                 = module.this.context
   global_environment_name = var.datadog_configuration_environment

--- a/src/provider-datadog.tf
+++ b/src/provider-datadog.tf
@@ -1,6 +1,5 @@
 module "datadog_configuration" {
-  source  = "github.com/cloudposse-terraform-components/aws-datadog-credentials/modules/datadog_keys"
-  version = "v1.535.0"
+  source = "git::https://github.com/cloudposse-terraform-components/aws-datadog-credentials.git//modules/datadog_keys?ref=v1.535.0"
 
   enabled                 = true
   context                 = module.this.context

--- a/src/provider-datadog.tf
+++ b/src/provider-datadog.tf
@@ -1,6 +1,5 @@
 module "datadog_configuration" {
   source                  = "github.com/cloudposse-terraform-components/aws-datadog-credentials?ref=v1.535.1"
-  version                 = "1.535.1"
   enabled                 = true
   context                 = module.this.context
   global_environment_name = var.datadog_configuration_environment

--- a/src/provider-datadog.tf
+++ b/src/provider-datadog.tf
@@ -1,7 +1,6 @@
 module "datadog_configuration" {
   source                  = "github.com/cloudposse-terraform-components/aws-datadog-credentials?ref=v1.535.1"
   version                 = "1.535.1"
-
   enabled                 = true
   context                 = module.this.context
   global_environment_name = var.datadog_configuration_environment

--- a/src/provider-datadog.tf
+++ b/src/provider-datadog.tf
@@ -1,5 +1,5 @@
 module "datadog_configuration" {
-  source = "git::https://github.com/cloudposse-terraform-components/aws-datadog-credentials.git//src/modules/datadog_keys?ref=v1.535.0"
+  source = "../datadog-configuration/modules/datadog_keys"
 
   enabled                 = true
   context                 = module.this.context

--- a/src/provider-datadog.tf
+++ b/src/provider-datadog.tf
@@ -1,5 +1,5 @@
 module "datadog_configuration" {
-  source                  = "github.com/cloudposse-terraform-components/aws-datadog-credentials?ref=v1.535.1"
+  source                  = "github.com/cloudposse-terraform-components/aws-datadog-credentials?tags=v1.535.1"
   enabled                 = true
   context                 = module.this.context
   global_environment_name = var.datadog_configuration_environment

--- a/src/provider-datadog.tf
+++ b/src/provider-datadog.tf
@@ -1,5 +1,7 @@
 module "datadog_configuration" {
   source                  = "github.com/cloudposse-terraform-components/aws-datadog-credentials?ref=v1.535.1"
+  version                 = "1.535.1"
+
   enabled                 = true
   context                 = module.this.context
   global_environment_name = var.datadog_configuration_environment


### PR DESCRIPTION
## what

This pull request includes a small change to the `src/main.tf` file. The change modifies the way `name_suffix` and `name` values are accessed within the `locals` block.

* [`src/main.tf`](diffhunk://#diff-1956abf05e8db0150fc12428093f137d1e9cca0a1d2d780a890c054274fb1e30L15-R16): Updated the access method for `name_suffix` and `name` values to use direct key access instead of the `lookup` function.

## why

- `lookup(map, key)` was useful in older Terraform versions when maps were sometimes nullable. Direct indexing (map["key"]) is now preferred because it is more readable, Terraform explicitly fails if the key doesn’t exist, and it aligns with standard programming practices

## references

- [TFLint Rules](https://github.com/terraform-linters/tflint-ruleset-terraform/tree/main/docs/rules)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Datadog configuration to use a specific remote module source and version.
  - Improved variable access method for name suffix in CloudWatch forwarder log groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->