### PR TITLE
update default python version to match module

### DIFF
--- a/src/variables.tf
+++ b/src/variables.tf
@@ -55,7 +55,7 @@ variable "dd_module_name" {
 variable "dd_forwarder_version" {
   type        = string
   description = "Version tag of Datadog lambdas to use. https://github.com/DataDog/datadog-serverless-functions/releases"
-  default     = "3.66.0"
+  default     = "3.116.0"
 }
 
 variable "forwarder_log_enabled" {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -25,7 +25,7 @@ variable "lambda_reserved_concurrent_executions" {
 variable "lambda_runtime" {
   type        = string
   description = "Runtime environment for Datadog Lambda"
-  default     = "python3.8"
+  default     = "python3.11"
 }
 
 variable "tracing_config_mode" {


### PR DESCRIPTION
## what

python 3.8 is deprecated. make default 3.11 like the module it's calling.

https://github.com/cloudposse/terraform-aws-datadog-lambda-forwarder/blob/main/variables.tf#L35

`We are contacting you as we have identified that your AWS Account currently has one or more AWS Lambda functions using the Python 3.8 runtime.
We are ending support for Python 3.8 in Lambda on October 14, 2024. This follows Python 3.8 End-Of-Life (EOL) which is scheduled for October, 2024 [1].`

## why
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default Python runtime version to 3.11
  * Updated default Datadog Forwarder version to 3.116.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->