### PR TITLE
fix: set upper bound on datadog provider to < 4.0.0

### DIFF
--- a/src/versions.tf
+++ b/src/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.3.0"
+      version = ">= 3.3.0, < 4.0.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Pins the `datadog/datadog` provider to `>= 3.3.0, < 4.0.0` to prevent pulling v4.x which removed `datadog_integration_aws_lambda_arn` and `datadog_integration_aws_log_collection` resource types
- Follows up on #103 which removed the AWS provider upper bound — that change allowed the latest datadog provider to be pulled, exposing this breaking change

## Context
The `datadog/datadog` provider v4.0.0 removed several resource types used by this component:
- `datadog_integration_aws_lambda_arn`
- `datadog_integration_aws_log_collection`

This causes `terraform plan/apply` to fail with `Invalid resource type` errors on the v2.0.0 release.

## Test plan
- [ ] `terraform init` resolves datadog provider to a 3.x version
- [ ] `terraform plan` no longer errors on the removed resource types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Datadog Terraform provider version constraint to maintain compatibility with the 3.x release line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->