### PR TITLE
Bump cloudposse/datadog-lambda-forwarder/aws to 1.10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,22 +150,22 @@ components:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0.0 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.3.0, < 4.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.3.0 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.3.0, < 4.0.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_datadog-integration"></a> [datadog-integration](#module\_datadog-integration) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
-| <a name="module_datadog_configuration"></a> [datadog\_configuration](#module\_datadog\_configuration) | github.com/cloudposse-terraform-components/aws-datadog-credentials//src/modules/datadog_keys | v1.535.13 |
-| <a name="module_datadog_lambda_forwarder"></a> [datadog\_lambda\_forwarder](#module\_datadog\_lambda\_forwarder) | cloudposse/datadog-lambda-forwarder/aws | 1.10.0 |
+| <a name="module_datadog_configuration"></a> [datadog\_configuration](#module\_datadog\_configuration) | github.com/cloudposse-terraform-components/aws-datadog-credentials//src/modules/datadog_keys | v2.0.0 |
+| <a name="module_datadog_lambda_forwarder"></a> [datadog\_lambda\_forwarder](#module\_datadog\_lambda\_forwarder) | cloudposse/datadog-lambda-forwarder/aws | 1.10.1 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles | v1.537.1 |
 | <a name="module_log_group_prefix"></a> [log\_group\_prefix](#module\_log\_group\_prefix) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |

--- a/src/README.md
+++ b/src/README.md
@@ -99,22 +99,22 @@ components:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0.0 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.3.0, < 4.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.3.0 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.3.0, < 4.0.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_datadog-integration"></a> [datadog-integration](#module\_datadog-integration) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
-| <a name="module_datadog_configuration"></a> [datadog\_configuration](#module\_datadog\_configuration) | github.com/cloudposse-terraform-components/aws-datadog-credentials//src/modules/datadog_keys | v1.535.13 |
-| <a name="module_datadog_lambda_forwarder"></a> [datadog\_lambda\_forwarder](#module\_datadog\_lambda\_forwarder) | cloudposse/datadog-lambda-forwarder/aws | 1.10.0 |
+| <a name="module_datadog_configuration"></a> [datadog\_configuration](#module\_datadog\_configuration) | github.com/cloudposse-terraform-components/aws-datadog-credentials//src/modules/datadog_keys | v2.0.0 |
+| <a name="module_datadog_lambda_forwarder"></a> [datadog\_lambda\_forwarder](#module\_datadog\_lambda\_forwarder) | cloudposse/datadog-lambda-forwarder/aws | 1.10.1 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles | v1.537.1 |
 | <a name="module_log_group_prefix"></a> [log\_group\_prefix](#module\_log\_group\_prefix) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |

--- a/src/main.tf
+++ b/src/main.tf
@@ -41,7 +41,7 @@ module "log_group_prefix" {
 
 module "datadog_lambda_forwarder" {
   source  = "cloudposse/datadog-lambda-forwarder/aws"
-  version = "1.10.0"
+  version = "1.10.1"
 
   cloudwatch_forwarder_log_groups     = local.cloudwatch_forwarder_log_groups
   cloudwatch_forwarder_event_patterns = var.cloudwatch_forwarder_event_patterns


### PR DESCRIPTION
## what

- Bump `cloudposse/datadog-lambda-forwarder/aws` in `src/main.tf` from **`1.10.0`** → **`1.10.1`**
- Regenerate `README.md` / `src/README.md` via `atmos readme`

## why

- `1.10.1` (https://github.com/cloudposse/terraform-aws-datadog-lambda-forwarder/releases/tag/v1.10.1) picks up the transitive bump of `cloudposse/cloudwatch-events/aws` from `0.6.1` → `0.10.0`
- That, in turn, replaces the internal `cloudposse/label/null` `0.22.0` (5-dimension) with `0.25.0` (6-dimension, supports `tenant`)
- Fixes `Error: Invalid index ... local.id_context is object with 5 attributes` on `local.id_context["tenant"]` for every consumer that sets `cloudwatch_forwarder_event_patterns` together with a `label_order` that includes `tenant` — i.e., every multi-tenant Cloud Posse setup
- Patch-level change: no public interface additions/removals, purely a transitive dependency bump that unblocks a runtime failure

## references

- Upstream module release: https://github.com/cloudposse/terraform-aws-datadog-lambda-forwarder/releases/tag/v1.10.1
- Upstream PR that cut the release: https://github.com/cloudposse/terraform-aws-datadog-lambda-forwarder/pull/107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AWS provider version requirements
  * Updated Datadog provider and module dependency versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->