### PR TITLE
feat: expose lambda_architectures and forwarder_use_cache_bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ components:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.3.0, < 4.0.0 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.91.0 |
 
 ## Modules
 
@@ -210,6 +210,7 @@ components:
 | <a name="input_forwarder_rds_enabled"></a> [forwarder\_rds\_enabled](#input\_forwarder\_rds\_enabled) | Flag to enable or disable Datadog RDS enhanced monitoring forwarder | `bool` | `false` | no |
 | <a name="input_forwarder_rds_filter_pattern"></a> [forwarder\_rds\_filter\_pattern](#input\_forwarder\_rds\_filter\_pattern) | Filter pattern for Lambda forwarder RDS | `string` | `""` | no |
 | <a name="input_forwarder_rds_layers"></a> [forwarder\_rds\_layers](#input\_forwarder\_rds\_layers) | List of Lambda Layer Version ARNs (maximum of 5) to attach to Datadog RDS enhanced monitoring lambda function | `list(string)` | `[]` | no |
+| <a name="input_forwarder_use_cache_bucket"></a> [forwarder\_use\_cache\_bucket](#input\_forwarder\_use\_cache\_bucket) | Flag to enable or disable the cache bucket for lambda tags and failed events. See https://docs.datadoghq.com/logs/guide/forwarder/?tab=cloudformation#upgrade-an-older-version-to-31060. Recommended for forwarder versions 3.106 and higher. | `bool` | `true` | no |
 | <a name="input_forwarder_vpc_logs_artifact_url"></a> [forwarder\_vpc\_logs\_artifact\_url](#input\_forwarder\_vpc\_logs\_artifact\_url) | The URL for the code of the Datadog forwarder for VPC Logs. It can be a local file, url or git repo | `string` | `null` | no |
 | <a name="input_forwarder_vpc_logs_enabled"></a> [forwarder\_vpc\_logs\_enabled](#input\_forwarder\_vpc\_logs\_enabled) | Flag to enable or disable Datadog VPC flow log forwarder | `bool` | `false` | no |
 | <a name="input_forwarder_vpc_logs_layers"></a> [forwarder\_vpc\_logs\_layers](#input\_forwarder\_vpc\_logs\_layers) | List of Lambda Layer Version ARNs (maximum of 5) to attach to Datadog VPC flow log forwarder lambda function | `list(string)` | `[]` | no |
@@ -220,6 +221,7 @@ components:
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |
 | <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br/>Default is to include all labels.<br/>Tags with empty values will not be included in the `tags` output.<br/>Set to `[]` to suppress all generated tags.<br/>**Notes:**<br/>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br/>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br/>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
+| <a name="input_lambda_architectures"></a> [lambda\_architectures](#input\_lambda\_architectures) | Instruction set architecture for the Datadog Lambda function. Valid values are ["x86\_64"] and ["arm64"]. Set to ["arm64"] when using Datadog Forwarder 5.x artifacts. | `list(string)` | `null` | no |
 | <a name="input_lambda_arn_enabled"></a> [lambda\_arn\_enabled](#input\_lambda\_arn\_enabled) | Enable adding the Lambda Arn to this account integration | `bool` | `true` | no |
 | <a name="input_lambda_policy_source_json"></a> [lambda\_policy\_source\_json](#input\_lambda\_policy\_source\_json) | Additional IAM policy document that can optionally be passed and merged with the created policy document | `string` | `""` | no |
 | <a name="input_lambda_reserved_concurrent_executions"></a> [lambda\_reserved\_concurrent\_executions](#input\_lambda\_reserved\_concurrent\_executions) | Amount of reserved concurrent executions for the lambda function. A value of 0 disables Lambda from being triggered and -1 removes any concurrency limitations. Defaults to Unreserved Concurrency Limits -1 | `number` | `-1` | no |

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ components:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.91.0 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.3.0, < 4.0.0 |
 
 ## Modules
 

--- a/src/README.md
+++ b/src/README.md
@@ -106,7 +106,7 @@ components:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.3.0, < 4.0.0 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.91.0 |
 
 ## Modules
 
@@ -159,6 +159,7 @@ components:
 | <a name="input_forwarder_rds_enabled"></a> [forwarder\_rds\_enabled](#input\_forwarder\_rds\_enabled) | Flag to enable or disable Datadog RDS enhanced monitoring forwarder | `bool` | `false` | no |
 | <a name="input_forwarder_rds_filter_pattern"></a> [forwarder\_rds\_filter\_pattern](#input\_forwarder\_rds\_filter\_pattern) | Filter pattern for Lambda forwarder RDS | `string` | `""` | no |
 | <a name="input_forwarder_rds_layers"></a> [forwarder\_rds\_layers](#input\_forwarder\_rds\_layers) | List of Lambda Layer Version ARNs (maximum of 5) to attach to Datadog RDS enhanced monitoring lambda function | `list(string)` | `[]` | no |
+| <a name="input_forwarder_use_cache_bucket"></a> [forwarder\_use\_cache\_bucket](#input\_forwarder\_use\_cache\_bucket) | Flag to enable or disable the cache bucket for lambda tags and failed events. See https://docs.datadoghq.com/logs/guide/forwarder/?tab=cloudformation#upgrade-an-older-version-to-31060. Recommended for forwarder versions 3.106 and higher. | `bool` | `true` | no |
 | <a name="input_forwarder_vpc_logs_artifact_url"></a> [forwarder\_vpc\_logs\_artifact\_url](#input\_forwarder\_vpc\_logs\_artifact\_url) | The URL for the code of the Datadog forwarder for VPC Logs. It can be a local file, url or git repo | `string` | `null` | no |
 | <a name="input_forwarder_vpc_logs_enabled"></a> [forwarder\_vpc\_logs\_enabled](#input\_forwarder\_vpc\_logs\_enabled) | Flag to enable or disable Datadog VPC flow log forwarder | `bool` | `false` | no |
 | <a name="input_forwarder_vpc_logs_layers"></a> [forwarder\_vpc\_logs\_layers](#input\_forwarder\_vpc\_logs\_layers) | List of Lambda Layer Version ARNs (maximum of 5) to attach to Datadog VPC flow log forwarder lambda function | `list(string)` | `[]` | no |
@@ -169,6 +170,7 @@ components:
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |
 | <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br/>Default is to include all labels.<br/>Tags with empty values will not be included in the `tags` output.<br/>Set to `[]` to suppress all generated tags.<br/>**Notes:**<br/>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br/>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br/>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
+| <a name="input_lambda_architectures"></a> [lambda\_architectures](#input\_lambda\_architectures) | Instruction set architecture for the Datadog Lambda function. Valid values are ["x86\_64"] and ["arm64"]. Set to ["arm64"] when using Datadog Forwarder 5.x artifacts. | `list(string)` | `null` | no |
 | <a name="input_lambda_arn_enabled"></a> [lambda\_arn\_enabled](#input\_lambda\_arn\_enabled) | Enable adding the Lambda Arn to this account integration | `bool` | `true` | no |
 | <a name="input_lambda_policy_source_json"></a> [lambda\_policy\_source\_json](#input\_lambda\_policy\_source\_json) | Additional IAM policy document that can optionally be passed and merged with the created policy document | `string` | `""` | no |
 | <a name="input_lambda_reserved_concurrent_executions"></a> [lambda\_reserved\_concurrent\_executions](#input\_lambda\_reserved\_concurrent\_executions) | Amount of reserved concurrent executions for the lambda function. A value of 0 disables Lambda from being triggered and -1 removes any concurrency limitations. Defaults to Unreserved Concurrency Limits -1 | `number` | `-1` | no |

--- a/src/README.md
+++ b/src/README.md
@@ -106,7 +106,7 @@ components:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.91.0 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.3.0, < 4.0.0 |
 
 ## Modules
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -64,11 +64,13 @@ module "datadog_lambda_forwarder" {
   forwarder_rds_enabled                 = var.forwarder_rds_enabled
   forwarder_rds_filter_pattern          = var.forwarder_rds_filter_pattern
   forwarder_rds_layers                  = var.forwarder_rds_layers
+  forwarder_use_cache_bucket            = var.forwarder_use_cache_bucket
   forwarder_vpc_logs_artifact_url       = var.forwarder_vpc_logs_artifact_url
   forwarder_vpc_logs_enabled            = var.forwarder_vpc_logs_enabled
   forwarder_vpc_logs_layers             = var.forwarder_vpc_logs_layers
   forwarder_vpclogs_filter_pattern      = var.forwarder_vpclogs_filter_pattern
   kms_key_id                            = var.kms_key_id
+  lambda_architectures                  = var.lambda_architectures
   lambda_policy_source_json             = var.lambda_policy_source_json
   lambda_reserved_concurrent_executions = var.lambda_reserved_concurrent_executions
   lambda_runtime                        = var.lambda_runtime

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -32,6 +32,11 @@ variable "lambda_architectures" {
   type        = list(string)
   description = "Instruction set architecture for the Datadog Lambda function. Valid values are [\"x86_64\"] and [\"arm64\"]. Set to [\"arm64\"] when using Datadog Forwarder 5.x artifacts."
   default     = null
+
+  validation {
+    condition     = var.lambda_architectures == null ? true : alltrue([for a in var.lambda_architectures : contains(["x86_64", "arm64"], a)])
+    error_message = "lambda_architectures must be null or a list containing only \"x86_64\" and/or \"arm64\"."
+  }
 }
 
 variable "tracing_config_mode" {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -28,6 +28,12 @@ variable "lambda_runtime" {
   default     = "python3.11"
 }
 
+variable "lambda_architectures" {
+  type        = list(string)
+  description = "Instruction set architecture for the Datadog Lambda function. Valid values are [\"x86_64\"] and [\"arm64\"]. Set to [\"arm64\"] when using Datadog Forwarder 5.x artifacts."
+  default     = null
+}
+
 variable "tracing_config_mode" {
   type        = string
   description = "Can be either PassThrough or Active. If PassThrough, Lambda will only trace the request from an upstream service if it contains a tracing header with 'sampled=1'. If Active, Lambda will respect any tracing header it receives from an upstream service"
@@ -80,6 +86,12 @@ variable "forwarder_log_retention_days" {
   type        = number
   description = "Number of days to retain Datadog forwarder lambda execution logs. One of [0 1 3 5 7 14 30 60 90 120 150 180 365 400 545 731 1827 3653]"
   default     = 14
+}
+
+variable "forwarder_use_cache_bucket" {
+  type        = bool
+  description = "Flag to enable or disable the cache bucket for lambda tags and failed events. See https://docs.datadoghq.com/logs/guide/forwarder/?tab=cloudformation#upgrade-an-older-version-to-31060. Recommended for forwarder versions 3.106 and higher."
+  default     = true
 }
 
 variable "kms_key_id" {


### PR DESCRIPTION
## Summary

- Pass `lambda_architectures` and `forwarder_use_cache_bucket` through to the upstream `cloudposse/datadog-lambda-forwarder/aws` module (pinned at `1.10.1`), and add matching wrapper variables.
- Enables consumers to run **Datadog Forwarder 5.x** artifacts by setting `lambda_architectures = ["arm64"]`. Those artifacts ship native dependencies built for arm64 and fail on `x86_64` during cold start with errors such as `Runtime.ImportModuleError: No module named 'ujson'`, which silently stops CloudWatch logs from reaching Datadog.
- Lets a stack explicitly control the forwarder cache bucket via `forwarder_use_cache_bucket` (default `true`, preserving upstream behavior).

## Changes

- `src/main.tf`: forward `lambda_architectures` and `forwarder_use_cache_bucket` to the upstream module. (`lambda_runtime` was already wired through.)
- `src/variables.tf`:
  - `lambda_architectures` — `list(string)`, default `null` (no change until a stack opts in).
  - `forwarder_use_cache_bucket` — `bool`, default `true` (matches upstream default).
- `README.md` / `src/README.md`: regenerated Inputs tables to document the new variables.

## Testing

- [x] `terraform fmt -check -recursive` — clean
- [x] `terraform validate` — Success (only pre-existing, unrelated `datadog_integration_aws_lambda_arn` deprecation warnings)
- [x] Verified both variables exist with matching type/default in upstream module `1.10.1`

## Notes

- Both defaults are chosen to be no-ops, so existing stacks are unaffected until they explicitly set the new variables.
- Upstreams wrapper changes originally made downstream by Prezzee.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Lambda architecture options.
  * Added a new setting to enable or disable use of a cache bucket.

* **Documentation**
  * Updated the setup docs with the latest supported provider version.
  * Documented the new configuration options and their defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->